### PR TITLE
Allow for multi_json 1.x.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,5 @@ group :development do
   gem 'fakeweb', '~> 1.3'
   gem 'jnunemaker-matchy', '~> 0.4'
   gem 'json_pure', '~> 1.4'
-  gem 'multi_json', '>= 0.0.5', '< 1.0.0'
+  gem 'multi_json', '>= 0.0.5', '< 2.0.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,17 @@ GEM
       addressable (~> 2.2.4)
       multipart-post (~> 1.1.0)
       rack (< 2, >= 1.1.0)
-    faraday_middleware (0.6.0)
+    faraday_middleware (0.6.3)
       faraday (~> 0.6.0)
     git (1.2.5)
     hashie (1.0.0)
-    jeweler (1.5.2)
+    jeweler (1.6.0)
       bundler (~> 1.0.0)
       git (>= 1.2.5)
       rake
     jnunemaker-matchy (0.4.0)
     json_pure (1.5.1)
-    multi_json (0.0.5)
+    multi_json (1.0.2)
     multipart-post (1.1.1)
     rack (1.2.2)
     rake (0.8.7)
@@ -36,6 +36,6 @@ DEPENDENCIES
   jeweler (~> 1.5)
   jnunemaker-matchy (~> 0.4)
   json_pure (~> 1.4)
-  multi_json (>= 0.0.5, < 1.0.0)
+  multi_json (>= 0.0.5, < 2.0.0)
   rcov
   shoulda

--- a/foursquare2.gemspec
+++ b/foursquare2.gemspec
@@ -63,19 +63,8 @@ Gem::Specification.new do |s|
   s.homepage = %q{http://github.com/mattmueller/foursquare2}
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.4.2}
+  s.rubygems_version = %q{1.6.2}
   s.summary = %q{Foursquare API v2 gem in the spirit of the original foursquare gem}
-  s.test_files = [
-    "test/config.rb",
-    "test/helper.rb",
-    "test/test_checkins.rb",
-    "test/test_client.rb",
-    "test/test_photos.rb",
-    "test/test_specials.rb",
-    "test/test_tips.rb",
-    "test/test_users.rb",
-    "test/test_venues.rb"
-  ]
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
@@ -91,7 +80,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<fakeweb>, ["~> 1.3"])
       s.add_development_dependency(%q<jnunemaker-matchy>, ["~> 0.4"])
       s.add_development_dependency(%q<json_pure>, ["~> 1.4"])
-      s.add_development_dependency(%q<multi_json>, [">= 0.0.5", "< 1.0.0"])
+      s.add_development_dependency(%q<multi_json>, ["< 2.0.0", ">= 0.0.5"])
     else
       s.add_dependency(%q<faraday>, ["~> 0.6"])
       s.add_dependency(%q<faraday_middleware>, ["~> 0.6"])
@@ -103,7 +92,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<fakeweb>, ["~> 1.3"])
       s.add_dependency(%q<jnunemaker-matchy>, ["~> 0.4"])
       s.add_dependency(%q<json_pure>, ["~> 1.4"])
-      s.add_dependency(%q<multi_json>, [">= 0.0.5", "< 1.0.0"])
+      s.add_dependency(%q<multi_json>, ["< 2.0.0", ">= 0.0.5"])
     end
   else
     s.add_dependency(%q<faraday>, ["~> 0.6"])
@@ -116,7 +105,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<fakeweb>, ["~> 1.3"])
     s.add_dependency(%q<jnunemaker-matchy>, ["~> 0.4"])
     s.add_dependency(%q<json_pure>, ["~> 1.4"])
-    s.add_dependency(%q<multi_json>, [">= 0.0.5", "< 1.0.0"])
+    s.add_dependency(%q<multi_json>, ["< 2.0.0", ">= 0.0.5"])
   end
 end
 


### PR DESCRIPTION
Sorry about not including this in the last set of commits. I've needed to use multi_json 1.x.x on a project of mine and didn't notice that the Gemfile I last pushed only allowed multi_json 0.x.x. All test pass for 1.x.x.
