### PR TITLE
Response attribute added to APIError

### DIFF
--- a/lib/foursquare2/api_error.rb
+++ b/lib/foursquare2/api_error.rb
@@ -4,11 +4,13 @@ module Foursquare2
     attr_reader :code
     attr_reader :detail
     attr_reader :type
+    attr_reader :response
 
-    def initialize(error)
+    def initialize(error, response)
       @code   = error.code
       @detail = error.errorDetail
       @type   = error.errorType
+      @response = response
     end
 
     def message

--- a/lib/foursquare2/client.rb
+++ b/lib/foursquare2/client.rb
@@ -68,7 +68,7 @@ module Foursquare2
       if response.body.meta.code == 200 
         response_body
       else
-        raise Foursquare2::APIError.new(response.body.meta) 
+        raise Foursquare2::APIError.new(response.body.meta, response.body.response)
       end
     end
       


### PR DESCRIPTION
"response" attribute added to Foursquare2::APIError to handle cases like duplicate venue (https://developer.foursquare.com/docs/venues/add.html) when response body also contains useful information.
