### PR TITLE
Add support for API versioning.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,9 @@ Currently this gem does not handle the oauth2 authentication flow for you, use t
 
     client = Foursquare2::Client.new(:oauth_token => 'user_oauth_token')
 
+### Instantiate a client (With versioning)
+
+    client = Foursquare2::Client.new(:api_version => '20120505')
 
 ### Examples
 

--- a/lib/foursquare2/client.rb
+++ b/lib/foursquare2/client.rb
@@ -12,7 +12,7 @@ module Foursquare2
     include Specials
     include Users
 
-    attr_reader :client_id, :client_secret, :oauth_token
+    attr_reader :client_id, :client_secret, :oauth_token, :api_version
 
     #Initialize the client class that will be used for all foursquare API requests.  Note that either a valid user oauth token OR a valid client_id + secret is required.
     #
@@ -22,12 +22,14 @@ module Foursquare2
     # @option options String :client_id Your foursquare app's client_id
     # @option options String :client_secret Your foursquare app's client_secret
     # @option options String :oauth_token A valid oauth token for a user (or the 'secret' value from api v1)
+    # @option options String :api_version A date formatted as YYYYMMDD indicating the API version you intend to use
     # @option options Hash   :ssl Additional SSL options (like the path to certificate file)
 
     def initialize(options={})
       @client_id = options[:client_id]
       @client_secret = options[:client_secret]
       @oauth_token = options[:oauth_token]
+      @api_version = options[:api_version]
       @ssl = options[:ssl].nil? ? Hash.new : options[:ssl]
     end
 
@@ -42,6 +44,7 @@ module Foursquare2
       params[:client_id] = @client_id if @client_id
       params[:client_secret] = @client_secret if @client_secret
       params[:oauth_token] = @oauth_token if @oauth_token
+      params[:v] = @api_version if @api_version
       @connection ||= Faraday::Connection.new(:url => api_url, :ssl => @ssl, :params => params, :headers => default_headers) do |builder|
         builder.use Faraday::Request::Multipart
         builder.use Faraday::Request::UrlEncoded

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class TestClient < Test::Unit::TestCase
   
- context "when instantiating a client instance" do
+  context "when instantiating a client instance" do
     should "use the correct url for api requests" do
       @client = Foursquare2::Client.new
       @client.api_url.should == 'https://api.foursquare.com/v2'
@@ -19,6 +19,11 @@ class TestClient < Test::Unit::TestCase
       @client.client_secret.should == 'sauce'
     end
     
+    should "retain api version for requests" do
+      @client = Foursquare2::Client.new(:api_version => '20120505')
+      @client.api_version.should == "20120505"
+    end
+
     should "retain SSL option for requests when you don't pass it as param" do
       @client = Foursquare2::Client.new(:client_id => 'awesome', :client_secret => 'sauce')
       @client.ssl.should == {}


### PR DESCRIPTION
Foursquare's API now accepts a "v" (version) parameter in all requests to specify the API version you want to use (See: https://developer.foursquare.com/overview/versioning).

I added an :api_version option to the Foursquare2 client initializer to allow specifying the API version to use.
