### PR TITLE
Allows configuring at the class level

### DIFF
--- a/lib/foursquare2.rb
+++ b/lib/foursquare2.rb
@@ -6,6 +6,10 @@ directory = File.expand_path(File.dirname(__FILE__))
 module Foursquare2
   class << self
 
+    FIELDS = [ :client_id, :client_secret, :api_version,
+               :ssl, :connection_middleware ]
+    attr_accessor(*FIELDS)
+
     def filter tips, term
       tip = []
       unless tips.nil?
@@ -14,6 +18,11 @@ module Foursquare2
         end
       end
       Hashie::Mash.new({:count => tip.count, :items => tip })
+    end
+
+    def configure
+      yield self
+      true
     end
 
   end

--- a/lib/foursquare2/client.rb
+++ b/lib/foursquare2/client.rb
@@ -38,12 +38,12 @@ module Foursquare2
     # @option options Hash   :ssl Additional SSL options (like the path to certificate file)
 
     def initialize(options={})
-      @client_id = options[:client_id]
-      @client_secret = options[:client_secret]
+      @client_id = options[:client_id] || Foursquare2.client_id
+      @client_secret = options[:client_secret] || Foursquare2.client_secret
       @oauth_token = options[:oauth_token]
-      @api_version = options[:api_version]
-      @ssl = options[:ssl].nil? ? Hash.new : options[:ssl]
-      @connection_middleware = options.fetch(:connection_middleware, [])
+      @api_version = options[:api_version] || Foursquare2.api_version
+      @ssl = options[:ssl] || Foursquare2.ssl || Hash.new
+      @connection_middleware = options[:connection_middleware] || Foursquare2.connection_middleware || []
       @connection_middleware += DEFAULT_CONNECTION_MIDDLEWARE
     end
 

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -1,7 +1,44 @@
 require 'helper'
 
 class TestClient < Test::Unit::TestCase
-  
+
+  context "when configuring the client at a class level" do
+    should "use the class-assigned attributes for new instances" do
+      Foursquare2.configure do |config|
+        config.client_id = 'awesome'
+        config.client_secret = 'sauce'
+        config.api_version = 5551234
+        config.ssl = true
+      end
+      client = Foursquare2::Client.new
+      client.client_id.should == 'awesome'
+      client.client_secret.should == 'sauce'
+      client.api_version.should == 5551234
+      client.ssl.should == true
+    end
+
+    should 'use the class-assigned middleware if provided' do
+      Foursquare2.configure do |config|
+        config.connection_middleware = [:middleware]
+      end
+      Faraday::Builder.any_instance.expects(:use).at_least_once
+      Faraday::Builder.any_instance.expects(:use) \
+        .with(:middleware)
+      client = Foursquare2::Client.new
+      client.connection
+    end
+
+    teardown do
+      Foursquare2.configure do |config|
+        config.client_id = nil
+        config.client_secret = nil
+        config.api_version = nil
+        config.connection_middleware = nil
+        config.ssl = nil
+      end
+    end
+  end
+
   context "when instantiating a client instance" do
     should "use the correct url for api requests" do
       @client = Foursquare2::Client.new
@@ -18,7 +55,7 @@ class TestClient < Test::Unit::TestCase
       @client.client_id.should == 'awesome'
       @client.client_secret.should == 'sauce'
     end
-    
+
     should "retain api version for requests" do
       @client = Foursquare2::Client.new(:api_version => '20120505')
       @client.api_version.should == "20120505"
@@ -28,9 +65,9 @@ class TestClient < Test::Unit::TestCase
       @client = Foursquare2::Client.new(:client_id => 'awesome', :client_secret => 'sauce')
       @client.ssl.should == {}
     end
-    
+
     should "retain SSL option for requests" do
-      @client = Foursquare2::Client.new(:client_id => 'awesome', :client_secret => 'sauce', :ssl => {:ca_file => 'path_to_ca_file'})      
+      @client = Foursquare2::Client.new(:client_id => 'awesome', :client_secret => 'sauce', :ssl => {:ca_file => 'path_to_ca_file'})
       @client.ssl[:ca_file].should == 'path_to_ca_file'
     end
 
@@ -63,7 +100,7 @@ class TestClient < Test::Unit::TestCase
     should "raise Foursquare2::Error." do
       response = Faraday::Response.new(:body => fixture_file('error.json', :parse => true))
       client   = Foursquare2::Client.new
-  
+
       assert_raises(Foursquare2::APIError) do
         client.return_error_or_body(response, response.body)
       end


### PR DESCRIPTION
This adds the ability to keep configuration logic in an initializer to avoid passing in a client_id and client_secret every time a new Foursquare2::Client object is created, especially since Foursquare allows developers to access their API without an Oauth token.  In addition, I think SSL and middleware configuration should be kept out of controllers and models.

I've created some tests around this feature as well. Usage is pretty self-explanatory:

``` ruby
Foursquare2.configure do |config|
  config.client_id = 'awesome'
  config.client_secret = 'sauce'
  config.api_version = 5551234
  config.connection_middleware = [:middleware]
  config.ssl = {:ca_file => 'path_to_ca_file'}
end
```
