### PR TITLE
Add locale support

### DIFF
--- a/lib/foursquare2/client.rb
+++ b/lib/foursquare2/client.rb
@@ -43,6 +43,7 @@ module Foursquare2
       @oauth_token = options[:oauth_token]
       @api_version = options[:api_version]
       @ssl = options[:ssl].nil? ? Hash.new : options[:ssl]
+      @locale = options[:locale]
       @connection_middleware = options.fetch(:connection_middleware, [])
       @connection_middleware += DEFAULT_CONNECTION_MIDDLEWARE
     end
@@ -59,6 +60,7 @@ module Foursquare2
       params[:client_secret] = @client_secret if @client_secret
       params[:oauth_token] = @oauth_token if @oauth_token
       params[:v] = @api_version if @api_version
+      params[:locale] = @locale if @locale
       @connection ||= Faraday::Connection.new(:url => api_url, :ssl => @ssl, :params => params, :headers => default_headers) do |builder|
         @connection_middleware.each do |middleware|
           builder.use *middleware


### PR DESCRIPTION
Add locale.

https://developer.foursquare.com/overview/versioning

```
Alternatively, you can add a locale=XXX
parameter to your request but HTTP header
specification is preferred. We currently support
en (default), es, fr, de, it, ja, th, ko, ru, pt, and id.
```

You can check this by

```
a = Foursquare2::Client.new(:client_id => client_id, :client_secret => client_secret, :locale => 'ru')
b = a.venue_categories
puts b[0].name
```
