### PR TITLE
Don't use 'sudo' to install a gem.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ Ruby wrapper for the [foursquare v2 API](http://developer.foursquare.com/docs/).
 
 ## Installation
 
-    sudo gem install foursquare2
+    gem install foursquare2
 
 ## Usage
 


### PR DESCRIPTION
It is pretty to install a gem with 'sudo'. If one of the gem's dependencies has malicious code in it, you're inviting the installer to pull code from the internet and run it with full permission! 

It's not necessary to install the gem so we shouldn't encourage people to use it.
