### PR TITLE
Include edit_venue options in body instead of url query

### DIFF
--- a/lib/foursquare2/venues.rb
+++ b/lib/foursquare2/venues.rb
@@ -27,7 +27,7 @@ module Foursquare2
       end
       return_error_or_body(response, response.body.response)
     end
-    
+
     # Search for trending venues
     #
     # @param [String] :ll Latitude and longitude in format LAT,LON
@@ -36,7 +36,7 @@ module Foursquare2
     # @option options Integer :radius - Radius in meters, up to approximately 2000 meters.
 
     def trending_venues(ll, options={})
-      options[:ll] = ll    
+      options[:ll] = ll
       response = connection.get do |req|
         req.url "venues/trending", options
       end
@@ -162,7 +162,8 @@ module Foursquare2
 
     def edit_venue(venue_id, options={})
       response = connection.post do |req|
-        req.url "venues/#{venue_id}/edit", options
+        req.body = options
+        req.url "venues/#{venue_id}/edit"
       end
       return_error_or_body(response, response.body.response)
     end


### PR DESCRIPTION
Playing with edit_venues method I noticed that POST request is done with empty body and all params are included in url query. When i do
`ruby
client.edit_venue('123', {'address' => 'example st. 1', ...})
`
It makes given request:
POST https://api.foursquare.com/v2/venues/123/edit?address=example%20st.%201&city=Examplepolis&description=This%20is%20my%20awesome%20profile&hours=0,0045,0415;1,0300,0400,Happy%20hours:%20from%203am%20to%205am;2,0300,0830;3,0615,0800;5,0200,2245&ll=123.45,321.09&name=Profile&oauth_token=abc123&phone=87654321&url=www.example.com&v=20140411&zip=0123456ABC {'Accept'=>'application/json', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Length'=>'0', 'User-Agent'=>'Ruby gem'}

I think we should include second param as request body and not as url query.

P.S. Sorry for my english :)
