### PR TITLE
#79 Include x-headers in response hash

### DIFF
--- a/lib/foursquare2/client.rb
+++ b/lib/foursquare2/client.rb
@@ -82,6 +82,7 @@ module Foursquare2
 
     def return_error_or_body(response, response_body)
       if response.body.meta.code == 200
+        response_body['x-headers'] = response.headers.select { |k,v| k.to_s.match(/^x-.*/) }
         response_body
       else
         raise Foursquare2::APIError.new(response.body.meta, response.body.response)


### PR DESCRIPTION
If this looks okay, then I can probably whip up some tests and docs too.
Here's how I'm using it:

```
    search = client.search_venues ll: [lat, lng].join(','), limit: limit, intent: 'checkin'
    $stdout.puts("measure#foursquare_venue_api_remaining=#{ search['x-headers']['x-ratelimit-remaining'] }")
```

I figure the probability of the key `x-headers` colliding with something in an actual response body is zero.
