### PR TITLE
Upgrades mocha version for ruby 2.1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,5 @@ group :development do
 end
 
 group :test do
-  gem 'mocha'
+  gem 'mocha', '~>1.1.0'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,7 +14,7 @@ require 'fakeweb'
 require 'json'
 require 'hashie'
 require 'awesome_print'
-require 'mocha'
+require 'mocha/mini_test'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Updating mocha's version to 1.1.X for compatibility reasons. [Issue link](http://stackoverflow.com/questions/20907138/rails-testing-error-nameerror-testcasesupports-info-signal)
