### PR TITLE
Add support for checkins/resolve endpoint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -69,6 +69,7 @@ See [the documentation](http://rubydoc.info/gems/foursquare2/frames) for a list 
 See [the documentation](http://rubydoc.info/gems/foursquare2/frames) or [foursquare's endpoint list](http://developer.foursquare.com/docs/index_docs.html) for parameters.
 
     client.checkin
+    client.resolve_checkin
     client.recent_checkins
     client.add_checkin
     client.add_checkin_comment

--- a/lib/foursquare2/checkins.rb
+++ b/lib/foursquare2/checkins.rb
@@ -14,6 +14,20 @@ module Foursquare2
       return_error_or_body(response, response.body.response.checkin)
     end
 
+    # Resolve checkin associated with a short ID at the end of a swarmapp.com link,
+    # e.g., https://swarmapp.com/c/abc123ZYX
+    #
+    # @param [Hash] options
+    # @option options String :shortId - ID at the end of a swarmapp.com link.
+
+    def resolve_checkin(options={})
+      response = connection.get do |req|
+        req.url "checkins/resolve", options
+      end
+      return_error_or_body(response, response.body.response.checkin)
+    end
+
+
     # Retrive a list of recent checkins from friends.
     #
     # @param [Hash] options

--- a/test/test_checkins.rb
+++ b/test/test_checkins.rb
@@ -14,6 +14,13 @@ class TestCheckins < Test::Unit::TestCase
       checkin.user.firstName.should == 'Matt'
     end
 
+    should "resolve a checkin by a short ID" do
+      stub_get("https://api.foursquare.com/v2/checkins/resolve?shortId=fP44HxXzikm&oauth_token=#{@client.oauth_token}", "checkins/checkin.json")
+      checkin = @client.resolve_checkin(shortId: 'fP44HxXzikm')
+      checkin.venue.name.should == 'Bridgestone Arena'
+      checkin.user.firstName.should == 'Matt'
+    end
+
     should "fetch recent checkins from friends"do
       stub_get("https://api.foursquare.com/v2/checkins/recent?oauth_token=#{@client.oauth_token}&limit=2", "checkins/friend_checkins.json")
       checkins = @client.recent_checkins(:limit => 2)


### PR DESCRIPTION
[fix #101]

Now clients can get an information about a checkin by a short ID at the
end of a swarmapp.com url like:
```
  client.resolve_checkin(shortId: 'dcBOk2Awmpj')
```